### PR TITLE
Make page lighter and add better feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <title>MD5 Passwords</title>
   <link rel="stylesheet" type="text/css" href="main.css">
   <link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet">
   <script type="text/javascript" src="sc.js"></script>
@@ -10,5 +11,6 @@
   <div id="black1">Password</div>
   <input id="pass" type="password" placeholder="Enter a Password">
   <button id="butt">Copy</button>
+  <div id="copied">Copied!</div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,19 +1,14 @@
+<!DOCTYPE html>
 <html>
 <head>
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-<link rel="stylesheet" type="text/css" href="main.css">
-<link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet">
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script type="text/javascript" src="sc.js"></script>
-<script src="https://cdn.jsdelivr.net/clipboard.js/1.5.12/clipboard.min.js"></script>
-
-
+  <meta charset="utf-8">
+  <link rel="stylesheet" type="text/css" href="main.css">
+  <link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet">
+  <script type="text/javascript" src="sc.js"></script>
 </head>
 <body>
-<div id="black1">
-    Password<br>
-</div>
-<input id="pass" class="asdf" type="password" value="Password Generator" >
-<button id="butt" onclick="invokeCopy();"> Copy </button>
+  <div id="black1">Password</div>
+  <input id="pass" type="password" placeholder="Enter a Password">
+  <button id="butt">Copy</button>
 </body>
 </html>

--- a/main.css
+++ b/main.css
@@ -29,3 +29,6 @@ button:active { color: #777; }
     color: white;
     padding: 0;
 }
+
+#copied { opacity: 0; font-size: 24px; transition: opacity 1s; }
+#copied.show { opacity: 1; transition: opacity 0.5s; }

--- a/main.css
+++ b/main.css
@@ -1,30 +1,31 @@
-body{
-	  display:flex;
+body {
+    background: white;
+    font-family: 'Merriweather', serif;
+    font-size: 70pt;
+    margin: 0;
+    line-height: 1.42;
+
+    display: flex;
     flex-direction: column;
+    align-items: center;
     justify-content: center;
-	font-family: 'Merriweather', serif;
-	font-size:70pt;
-}
-#black1{
-	width:100%;
-	text-align:center;
-	background-color:white;
-  margin-bottom:40px;
 }
 
-button{
-    margin-top:40px;
+input, button {  font: inherit;  }
+
+button {
     border: none;
-    background-color: white;
-
+    background: white;
 }
+button:hover { color: #444; }
+button:active { color: #777; }
 
-#pass{
-	color:black;
-	text-align:center;
-	background-color:#333333;
-	border:none;
-	color:white;
-	width:100%;
-	padding:0%;
+#pass {
+    margin: 40px 0;
+    text-align: center;
+    width: 100%;
+    background: #333;
+    border: none;
+    color: white;
+    padding: 0;
 }

--- a/main.css
+++ b/main.css
@@ -2,6 +2,7 @@ body {
     background: white;
     font-family: 'Merriweather', serif;
     font-size: 70pt;
+    height: 100vh;
     margin: 0;
     line-height: 1.42;
 

--- a/sc.js
+++ b/sc.js
@@ -198,12 +198,16 @@ var MD5 = function (string) {
 
    	return temp.toLowerCase();
 }
+
 function invokeCopy() {
     document.execCommand('copy');
 }
+
 function modifyCopy(e) {
-    
-    e.clipboardData.setData('text/plain', MD5($('#pass').val()));
+    var pass = document.getElementById('pass');
+    e.clipboardData.setData('text/plain', MD5(pass.value));
     e.preventDefault();
 }
+
+document.addEventListener('click', invokeCopy);
 document.addEventListener('copy', modifyCopy);

--- a/sc.js
+++ b/sc.js
@@ -207,6 +207,13 @@ function modifyCopy(e) {
     var pass = document.getElementById('pass');
     e.clipboardData.setData('text/plain', MD5(pass.value));
     e.preventDefault();
+
+    // Display a notification that it was copied
+    var copied = document.getElementById('copied');
+    copied.className = 'show';
+    window.setTimeout(function() {
+        copied.className = '';
+    }, 1000);
 }
 
 document.addEventListener('click', invokeCopy);


### PR DESCRIPTION
This removes dependencies on jQuery, bootstrap, and clipboard.js (none of which were getting used in any significant amount) and adds better visual feedback for when text has been copied.

This reduces the page size from about 350Kb to about 5Kb.

Fixes #1 